### PR TITLE
Add name attribute on game

### DIFF
--- a/lib/igdb/representers/game_representer.rb
+++ b/lib/igdb/representers/game_representer.rb
@@ -1,6 +1,7 @@
 module Igdb::GameRepresenter
   include Igdb::BaseRepresenter
 
+  property :name # The game's title.
   property :summary # Not documented in V1 API
   property :storyline
   property :collection


### PR DESCRIPTION
- I wanted to access the game name, but it wasn't a property.
- IGDB API endpoint provides game name, but gem did not
- Allows user to access game title